### PR TITLE
Add channel headers support to websocket and http clients

### DIFF
--- a/core/deps.edn
+++ b/core/deps.edn
@@ -9,11 +9,11 @@
            :pack   {:extra-deps {pack/pack.alpha {:git/url "https://github.com/juxt/pack.alpha.git"
                                                   :sha     "c70740ffc10805f34836da2160fa1899601fac02"}}
                     :main-opts  ["-m" "mach.pack.alpha.skinny" "--no-libs" "--project-path" "dist/json-rpc.core.jar"]}
-           :deploy {:extra-deps {deps-deploy {:mvn/version "RELEASE"}}
+           :deploy {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
                     :main-opts  ["-m" "deps-deploy.deps-deploy" "deploy"
                                  "dist/json-rpc.core.jar"]}}
- :deps    {camel-snake-kebab             {:mvn/version "0.4.1"}
-           clj-http                      {:mvn/version "3.10.1"}
+ :deps    {camel-snake-kebab/camel-snake-kebab             {:mvn/version "0.4.1"}
+           clj-http/clj-http              {:mvn/version "3.10.1"}
            com.github.jnr/jnr-unixsocket {:mvn/version "0.30"}
            org.clojure/clojure           {:mvn/version "1.10.1"}
            org.clojure/core.async        {:mvn/version "1.1.587"}

--- a/core/src/json_rpc/client.clj
+++ b/core/src/json_rpc/client.clj
@@ -3,6 +3,6 @@
 
 (defprotocol Client
   "A JSON-RPC client."
-  (open [this url] "Opens a connection to the given URL")
+  (open [this url headers] "Opens a connection to the given URL")
   (send [this conneciton message] "Sends a JSON-RPC request to the open connection")
   (close [this conneciton] "Closes the connection"))

--- a/core/src/json_rpc/core.clj
+++ b/core/src/json_rpc/core.clj
@@ -60,10 +60,10 @@
     (close-fn)))
 
 (defn open
-  [url & {route-fn :route-fn}]
+  [url & {route-fn :route-fn headers :headers}]
   (let [route-fn (or route-fn route)
         client   (route-fn url)
-        channel  (client/open client url)]
+        channel  (client/open client url headers)]
     (log/debugf "url => %s" url)
     (map->Channel {:send-fn  (partial client/send client channel)
                    :close-fn #(client/close client channel)})))

--- a/core/src/json_rpc/http.clj
+++ b/core/src/json_rpc/http.clj
@@ -32,12 +32,14 @@
 (defrecord CljHttpClient [options]
   client/Client
 
-  (open [this url]
-    {:url url})
+  (open [this url headers]
+    {:url url
+     :headers headers})
 
-  (send [this {url :url} message]
-    (->> {:body message}
-         (merge options)
+  (send [this {url :url headers :headers} message]
+    (->> (-> options
+             (update :headers merge headers)
+             (assoc :body message))
          (http/post url)
          :body))
 

--- a/core/src/json_rpc/unix.clj
+++ b/core/src/json_rpc/unix.clj
@@ -11,7 +11,7 @@
 (defrecord UnixSocketClient []
   client/Client
 
-  (open [this path]
+  (open [this path _headers]
     (-> path
         (io/file)
         (UnixSocketAddress.)

--- a/core/src/json_rpc/ws.clj
+++ b/core/src/json_rpc/ws.clj
@@ -6,10 +6,10 @@
 
 (defrecord GniazdoClient []
   client/Client
-  
-  (open [this url]
+
+  (open [this url headers]
     (let [source (async/chan)
-          socket (ws/connect url :on-receive #(>!! source %))]
+          socket (ws/connect url :on-receive #(>!! source %) :headers headers)]
       {:socket socket
        :source source}))
 

--- a/core/test/json_rpc/http_test.clj
+++ b/core/test/json_rpc/http_test.clj
@@ -30,7 +30,7 @@
   (testing "POST requests"
     (doseq [url ["http://postman-echo.com/post"
                  "https://postman-echo.com/post"]]
-      (let [channel (client/open clj-http url)]
+      (let [channel (client/open clj-http url {})]
         (try
           (let [request  {:jsonrpc "2.0"
                           :method  "eth_blockNumber"

--- a/core/test/json_rpc/ws_test.clj
+++ b/core/test/json_rpc/ws_test.clj
@@ -8,7 +8,7 @@
 (deftest ^:integration gniazdo-test
   (testing "with echo response"
     (doseq [url ["ws://echo.websocket.org"]]
-      (let [channel (client/open gniazdo url)]
+      (let [channel (client/open gniazdo url {})]
         (try
           (let [request  {:jsonrpc "2.0"
                           :method  "eth_blockNumber"


### PR DESCRIPTION
Hello @hindol,

Thanks for sharing this code!

For certain JSON-RPC servers, specific headers including `Authorization` may be required to authorize requests.

This adds an optional `:headers` keyword with a map of supplemental headers to send in the channel.

For a websocket, the headers are sent when the socket is opened; for an HTTP client, the headers are sent with each RPC.